### PR TITLE
Update default defstruct values with those passed by the user

### DIFF
--- a/lib/fsm.ex
+++ b/lib/fsm.ex
@@ -10,7 +10,7 @@ defmodule Fsm do
       @declared_events MapSet.new
 
       def new do
-        %__MODULE__{state: unquote(opts[:initial_state]), data: unquote(opts[:initial_data])}
+        %__MODULE__{}
       end
 
       def state(%__MODULE__{state: state}), do: state

--- a/lib/fsm.ex
+++ b/lib/fsm.ex
@@ -3,7 +3,8 @@ defmodule Fsm do
     quote do
       import Fsm
 
-      defstruct [:state, :data]
+      defstruct [state: unquote(opts[:initial_state]),
+                 data:  unquote(opts[:initial_data])]
 
       @declaring_state nil
       @declared_events MapSet.new


### PR DESCRIPTION
Hello @sasa1977,
Good job on this functional fsm. I like that.
Since the &new/0 function just give us the initial structure with the default values defined by the user, this values could be initiated as default values for the defstruct.
This permits using some libraries that need to abstract a module using struct(module) as the initial value of the module. In such a case using the &new/0 wouldn't fit.
I couldn't think on a case of using the %Module{} as an empty structure with no initial values.